### PR TITLE
[Bugfix] Stone Cost not initialized when creating units

### DIFF
--- a/src/UnitManager.cpp
+++ b/src/UnitManager.cpp
@@ -101,7 +101,7 @@ Unit UnitManager::constructFarm(Player &player) {
 
     u.lumberCost = 250;
     u.goldCost = 500;
-    u.stoneCarry = 0;
+    u.stoneCost = 0;
 
     if(u.config.instantBuilding) {
         u.spawnDuration = 0;
@@ -157,7 +157,7 @@ Unit UnitManager::constructBarracks(Player &player) {
 
     u.lumberCost = 450;
     u.goldCost = 700;
-    u.stoneCarry = 0;
+    u.stoneCost = 0;
 
     if(u.config.instantBuilding) {
         u.spawnDuration = 0;
@@ -221,7 +221,7 @@ Unit UnitManager::constructTownHall(Player &player) {
 
     u.lumberCost = 250;
     u.goldCost = 500;
-    u.stoneCarry = 0;
+    u.stoneCost = 0;
 
     if(u.config.instantBuilding) {
         u.spawnDuration = 0;
@@ -278,7 +278,7 @@ Unit UnitManager::constructPeasant(Player &player)
 
     u.lumberCost = 0;
     u.goldCost = 400;
-    u.stoneCarry = 0;
+    u.stoneCost = 0;
 
     if(u.config.instantBuilding) {
         u.spawnDuration = 0;
@@ -343,7 +343,7 @@ Unit UnitManager::constructFootman(Player &player) {
 
     u.lumberCost = 0;
     u.goldCost = 600;
-    u.stoneCarry = 0;
+    u.stoneCost = 0;
 
     if(u.config.instantBuilding) {
         u.spawnDuration = 0;
@@ -399,7 +399,7 @@ Unit UnitManager::constructArcher(Player &player) {
 
     u.lumberCost = 50;
     u.goldCost = 500;
-    u.stoneCarry = 0;
+    u.stoneCost = 0;
 
     if(u.config.instantBuilding) {
         u.spawnDuration = 0;


### PR DESCRIPTION
Hello, I've found a bug when spawning units. I noticed that when a player spawns a peasant unit, the  player would receive huge amounts of stone (either negative or positive amounts):

Cost for creating a peasant unit:
400,  0,          556288460
gold, lumber, stone

Finally found the cause for the bug, it seems to be a logical error where stoneCost is never initialized because of several spelling errors, causing random values for all available units.